### PR TITLE
adding support for DB2, dual inserts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL authors="Rafael Sene - rpsene@br.ibm.com"
 LABEL year="2021"
 
 RUN apt-get update; apt-get -y install pwgen python3 python3-pip libpq-dev \
-python-dev build-essential; pip3 install psycopg2; pip3 install pytz
+python-dev build-essential; pip3 install psycopg2; pip3 install pytz; pip3 install ibm_db
 
 ENV TABLE=""
 ENV CLUSTER_ID=""

--- a/database.ini
+++ b/database.ini
@@ -3,3 +3,9 @@ host=
 database=
 user=
 password=
+[db2]
+host=
+port=
+database=
+uid=
+pwd=


### PR DESCRIPTION
The main would call `insert_data` for PostgreSQL, as before, and now `insert_db2` as well for DB2. DB2 table is named "clusters" with assumptions for data width (see in code).

Tested by manually running `insert.py` locally with dummy params.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>